### PR TITLE
Search `topic` for subjects not `topicStr`

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -15,7 +15,7 @@ class Search
   Dotenv.load
 
   def initialize(indexes, terms)
-    @fields = 'id,ht_json,fullrecord,sdrnum,title,author,publishDate,publisher,topicStr'
+    @fields = 'id,ht_json,fullrecord,sdrnum,title,author,publishDate,publisher,topic'
     @indexes = indexes
     @terms = terms
     @page = 0

--- a/views/search_form.erb
+++ b/views/search_form.erb
@@ -18,7 +18,7 @@
   <input type="checkbox" name="indexes[]" value="author" <% if @indexes.include? "author" %>checked<% end %>/>Author<br />
   <input type="checkbox" name="indexes[]" value="publisher" <% if @indexes.include? "publisher" %>checked<% end %>/>Publisher<br/>
   <input type="checkbox" name="indexes[]" value="title" <% if @indexes.include? "title" %>checked<% end %>/>Title<br/>
-  <input type="checkbox" name="indexes[]" value="topicStr" <% if @indexes.include? "topicStr" %>checked<% end %>/>Subject<br/>
+  <input type="checkbox" name="indexes[]" value="topic" <% if @indexes.include? "topic" %>checked<% end %>/>Subject<br/>
   </fieldset>
   <fieldset>
   <legend>Search Terms</legend>


### PR DESCRIPTION
A subject search was using the topicStr field which appears to be normalized in such a way that results are being missed. This uses `topic` for the search instead. `topicStr` is still used for the report generation because it's the only stored subject field. 

I don't know how to test this or deploy it for that matter. 